### PR TITLE
Fix BASE_DIR path

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -4,7 +4,11 @@ from decouple import config, Csv
 from urllib.parse import urlparse
 from dotenv import load_dotenv
 
-BASE_DIR = Path(__file__).resolve().parent.parent.parent
+# BASE_DIR should point to the project root directory. ``config.py`` lives
+# inside ``core`` so we only need to go two levels up to reach the project
+# root. The previous version went three levels up which resulted in an
+# incorrect path like ``/workspace`` instead of ``/workspace/coolify-app1``.
+BASE_DIR = Path(__file__).resolve().parent.parent
 load_dotenv()
 
 env = os.getenv("DJANGO_ENV", "dev")


### PR DESCRIPTION
## Summary
- correct BASE_DIR path so static files and other resources use the project root

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68482e7fe4ac832b8ddc10c8712f3165